### PR TITLE
Fixes and amendments

### DIFF
--- a/src/c/bathlets.c
+++ b/src/c/bathlets.c
@@ -462,8 +462,7 @@ bathlets_analysis_initialize (int member, swt_wavelet *pWaveStruct)
 void
 bathlets_synthesis_initialize (int member, swt_wavelet *pWaveStruct)
 {
-
-  double *pFilterCoef;
+  //double *pFilterCoef;
 
   switch (member)
     {

--- a/src/c/bior.c
+++ b/src/c/bior.c
@@ -245,7 +245,7 @@ static const double hm6_68[18] = {
 void
 sp_bior_analysis_initialize (int member, swt_wavelet *pWaveStruct)
 {
-  double *pFilterCoef, *pFilterCoefMirror;
+  //double *pFilterCoef, *pFilterCoefMirror;
 
   switch (member) {
   case 11:
@@ -430,7 +430,7 @@ sp_bior_analysis_initialize (int member, swt_wavelet *pWaveStruct)
 void
 sp_bior_synthesis_initialize (int member, swt_wavelet *pWaveStruct)
 {
-  double *pFilterCoef, *pFilterCoefMirror;
+  //double *pFilterCoef, *pFilterCoefMirror;
 
 
   switch (member) {
@@ -616,7 +616,7 @@ sp_bior_synthesis_initialize (int member, swt_wavelet *pWaveStruct)
 void
 sp_rbior_analysis_initialize (int member, swt_wavelet *pWaveStruct)
 {
-  double *pFilterCoef, *pFilterCoefMirror;
+  //double *pFilterCoef, *pFilterCoefMirror;
 
   switch (member) {
   case 11:
@@ -801,7 +801,7 @@ sp_rbior_analysis_initialize (int member, swt_wavelet *pWaveStruct)
 void
 sp_rbior_synthesis_initialize (int member, swt_wavelet *pWaveStruct)
 {
-  double *pFilterCoef, *pFilterCoefMirror;
+  //double *pFilterCoef, *pFilterCoefMirror;
 
 
   switch (member) {

--- a/src/c/cwt.c
+++ b/src/c/cwt.c
@@ -788,10 +788,10 @@ void meyer_phi(double *x, int sigInLength,
 		xhat_r[count]=0;
 		xhat_i[count]=0;
 		xhat=0;
-	        if (abs(x[count]) <(2*PI/3))
+	        if (fabs(x[count]) <(2*PI/3))
 		  xhat=1;
-		if (abs(x[count]) >=(2*PI/3) && abs(x[count]) <(4*PI/3)){
-		  meyeraux(3/2/PI*abs(x[count])-1,&con);
+		if (fabs(x[count]) >=(2*PI/3) && fabs(x[count]) <(4*PI/3)){
+		  meyeraux(3/2/PI*fabs(x[count])-1,&con);
 		  xhat=cos(PI/2*con);
 		}
 

--- a/src/c/cwt.c
+++ b/src/c/cwt.c
@@ -672,7 +672,7 @@ void fbspwavf(double *x, int sigInLength,int m,
 			double fb, double fc, double *psir, double *psii,
 			int sigOutLength, double ys)
 {
-	int count, i;
+	int count /*, i*/;
 	double con, econ;
 
 	con = sqrt(fb);

--- a/src/c/dwt1d.c
+++ b/src/c/dwt1d.c
@@ -1038,7 +1038,7 @@ detcoef (double *sigIn, int sigInLength, int *waveDecLengthArray,
       for (count = 0; count < level; count++){
            //sciprint("tmp %d",tmp);
 			     leng +=waveDecLengthArray[stride - count];;
-			printf("");
+			//printf("");
 
 		  }
   }

--- a/src/c/dwt1d.c
+++ b/src/c/dwt1d.c
@@ -1164,7 +1164,7 @@ upwlev (double *coefArray, int coefLen, int *waveDecLengthArray,
 	int stride, extend_method extMethod)
 {
   int count, pos1;
-  char c='a';
+  //char c='a';
   double *app, *det;
 
   //printf("enter upwlev!\n");

--- a/src/c/dwt1d.c
+++ b/src/c/dwt1d.c
@@ -1111,14 +1111,13 @@ wrcoef (double *sigIn, int sigInLength, double *lowRe, double *hiRe,
 {
 
   int count = 0;
-  int startCount, endCount, leng;
+  int startCount, endCount, leng = 0;
   double *sigOutTemp;
 
   sigOutTemp = malloc (sigInLength * sizeof (double));
 
   if (level != 0)
     {
-      leng = 0;
       for (count = 0; count < level; count++)
 	leng += waveDecLengthArray[stride - count];
     }

--- a/src/c/dwt2d.c
+++ b/src/c/dwt2d.c
@@ -316,7 +316,7 @@ idwt2D (double *matrixInApprox, double *matrixInColDetail,
 	int matrixOutRow, int matrixOutCol, extend_method extMethod)
 {
   int row, col;
-  int filterOutLength;
+  //int filterOutLength;
   int matrixInRowM, matrixInColM;
   char c='b';
   double *matrixOutApproxPre, *matrixOutDetailPre;
@@ -350,7 +350,7 @@ idwt2D (double *matrixInApprox, double *matrixInColDetail,
 	      matrixInDetailM, matrixInRowM, matrixInColM,
 	      extMethod, &c, &c);
 
-  filterOutLength = 2 * matrixInRowM + filterLen - 1;
+  //filterOutLength = 2 * matrixInRowM + filterLen - 1;
 
   /* Approx Calculation */
   matrixOutApproxPre = malloc (matrixOutRow * matrixInColM * sizeof (double));
@@ -385,7 +385,7 @@ idwt2D (double *matrixInApprox, double *matrixInColDetail,
   free (matrixInDetailM);
 
   /* Final Inverse Transform */
-  filterOutLength = 2 * matrixInColM + filterLen - 1;
+  //filterOutLength = 2 * matrixInColM + filterLen - 1;
   matrixOutPre = malloc (matrixOutRow * matrixOutCol * sizeof (double));
   for (row = 0; row < matrixOutRow; row++)
     idwt_neo ((matrixOutApproxTemp + row * matrixInColM),
@@ -411,9 +411,9 @@ idwt2D_neo (double *matrixInApprox, double *matrixInColDetail,
 	int matrixOutRow, int matrixOutCol)
 {
   int row, col;
-  int filterOutLength;
+  //int filterOutLength;
   int matrixInRowM, matrixInColM;
-  char c='b';
+  //char c='b';
   double *matrixOutApproxPre, *matrixOutDetailPre;
   double *matrixOutApproxTemp, *matrixOutDetailTemp;
   double *matrixOutPre;
@@ -445,7 +445,7 @@ idwt2D_neo (double *matrixInApprox, double *matrixInColDetail,
 	//      matrixInDetailM, matrixInRowM, matrixInColM,
 	  //    extMethod, &c, &c);
 
-  filterOutLength = 2 * matrixInRowM + filterLen - 1;
+  //filterOutLength = 2 * matrixInRowM + filterLen - 1;
 
   /* Approx Calculation */
   matrixOutApproxPre = malloc (matrixOutRow * matrixInColM * sizeof (double));
@@ -480,7 +480,7 @@ idwt2D_neo (double *matrixInApprox, double *matrixInColDetail,
   //free (matrixInDetailM);
 
   /* Final Inverse Transform */
-  filterOutLength = 2 * matrixInColM + filterLen - 1;
+  //filterOutLength = 2 * matrixInColM + filterLen - 1;
   matrixOutPre = malloc (matrixOutRow * matrixOutCol * sizeof (double));
   for (row = 0; row < matrixOutRow; row++)
     idwt_neo ((matrixOutApproxTemp + row * matrixInColM),
@@ -1394,9 +1394,9 @@ idwt2D_neo_a (double *matrixInApprox, double *matrixInColDetail,
 	      int matrixOutRow, int matrixOutCol)
 {
   int row, col;
-  int filterOutLength;
+  //int filterOutLength;
   int matrixInRowM, matrixInColM;
-  char c='b';
+  //char c='b';
   double *matrixOutApproxPre, *matrixOutDetailPre;
   double *matrixOutApproxTemp, *matrixOutDetailTemp;
   double *matrixOutPre;
@@ -1405,7 +1405,7 @@ idwt2D_neo_a (double *matrixInApprox, double *matrixInColDetail,
   matrixInColM = matrixInCol;// + 2 * (filterLen - 1);
 
 
-  filterOutLength = 2 * matrixInRowM + filterLen - 1;
+  //filterOutLength = 2 * matrixInRowM + filterLen - 1;
 
   /* Approx Calculation */
   matrixOutApproxPre = malloc (matrixOutRow * matrixInColM * sizeof (double));
@@ -1436,7 +1436,7 @@ idwt2D_neo_a (double *matrixInApprox, double *matrixInColDetail,
   free (matrixOutDetailPre);
 
   /* Final Inverse Transform */
-  filterOutLength = 2 * matrixInColM + filterLen - 1;
+  //filterOutLength = 2 * matrixInColM + filterLen - 1;
   matrixOutPre = malloc (matrixOutRow * matrixOutCol * sizeof (double));
   for (row = 0; row < matrixOutRow; row++)
     idwt_neo ((matrixOutApproxTemp + row * matrixInColM),

--- a/src/c/dwt2d.c
+++ b/src/c/dwt2d.c
@@ -805,7 +805,7 @@ detcoef2 (double *coef, int sigInLength, double *coefOut,
 	  int sigOutLength, int *pLen, int stride, int level,
 	  char *coefType)
 {
-  int row, col, sta;
+  int row, col, sta = 0;
   int *pH, *pV, *pD;
 
   pH = malloc (stride * sizeof (int));
@@ -816,11 +816,11 @@ detcoef2 (double *coef, int sigInLength, double *coefOut,
     {
       sta = pH[stride - level];
     }
-  if (strcmp (coefType, "v") == 0)
+  else if (strcmp (coefType, "v") == 0)
     {
       sta = pV[stride - level];
     }
-  if (strcmp (coefType, "d") == 0)
+  else if (strcmp (coefType, "d") == 0)
     {
       sta = pD[stride - level];
     }
@@ -869,7 +869,7 @@ wrcoef2 (double *coef, int sigInLength, double *lowRe,
 	 int matrixOutRow, int matrixOutCol, int *pLen,
 	 int stride, int level, char *type, extend_method extMethod)
 {
-  int count, total, sta, si;
+  int count, total, sta = 0, si = 0;
   double *coefTemp;
   int *pH, *pV, *pD;
 
@@ -889,19 +889,19 @@ wrcoef2 (double *coef, int sigInLength, double *lowRe,
       sta = pH[stride - level];
       si = (pLen[(stride - level + 1) * 2]) * (pLen[(stride - level + 1) * 2 + 1]);
     }
-  if (strcmp (type, "v") == 0)
+  else if (strcmp (type, "v") == 0)
     {
       sta = pV[stride - level];
       si = (pLen[(stride - level + 1) * 2]) * (pLen[(stride - level + 1) * 2 + 1]);
     }
-  if (strcmp (type, "d") == 0)
+  else if (strcmp (type, "d") == 0)
     {
       sta = pD[stride - level];
       si = (pLen[(stride - level + 1) * 2]) * (pLen[(stride - level + 1) * 2 + 1]);
     }
-  if (strcmp (type, "a") == 0)
+  else if (strcmp (type, "a") == 0)
     {
-      sta = 0;
+      //sta = 0;
       si = (pLen[0]) * (pLen[1]);
       if (level != stride)
 	{

--- a/src/c/legendre.c
+++ b/src/c/legendre.c
@@ -151,9 +151,9 @@ static const double legd9[18] = {
 void
 legendre_analysis_initialize (int member, swt_wavelet *pWaveStruct)
 {
-//   double *pFilterCoef;
+  //double *pFilterCoef;
   //double sum;
-  int count;
+  //int count;
 
 
   switch (member)
@@ -255,9 +255,9 @@ legendre_analysis_initialize (int member, swt_wavelet *pWaveStruct)
 void
 legendre_synthesis_initialize (int member, swt_wavelet *pWaveStruct)
 {
-//   double *pFilterCoef;
+  //double *pFilterCoef;
   //double sum;
-  int count;
+  //int count;
 
 
   switch (member)


### PR DESCRIPTION
1. Use "fabs()" instead of "abs()" for floating-point numbers (warned by the Android NDK).
2. Initialize some variables before using (warned by the Android NDK).
3. Amend some if-else code blocks.
4. Disable some unused variables to avoid some warnings.